### PR TITLE
fix: Updated Spatial Persistence interface to report on Failed Anchors that were requested.

### DIFF
--- a/XRTK.SpatialPersistence/Packages/com.xrtk.spatial-persistence/Runtime/Interfaces/IMixedRealitySpatialPersistenceDataProvider.cs
+++ b/XRTK.SpatialPersistence/Packages/com.xrtk.spatial-persistence/Runtime/Interfaces/IMixedRealitySpatialPersistenceDataProvider.cs
@@ -172,6 +172,11 @@ namespace XRTK.Interfaces.SpatialPersistence
         /// </summary>
         event Action<Guid, GameObject> AnchorLocated;
 
+        /// <summary>
+        /// An error occured retrieving the selected Anchor and the data was invalid.
+        /// </summary>
+        event Action<Guid, string> AnchorLocatedError;
+
         #endregion Spatial Persistence Service Events
     }
 }

--- a/XRTK.SpatialPersistence/Packages/com.xrtk.spatial-persistence/Runtime/Interfaces/IMixedRealitySpatialPersistenceSystem.cs
+++ b/XRTK.SpatialPersistence/Packages/com.xrtk.spatial-persistence/Runtime/Interfaces/IMixedRealitySpatialPersistenceSystem.cs
@@ -108,6 +108,11 @@ namespace XRTK.Interfaces.SpatialPersistence
         /// </summary>
         event Action<Guid, GameObject> AnchorLocated;
 
+        /// <summary>
+        /// An error occured retrieving the selected Anchor and the data was invalid.
+        /// </summary>
+        event Action<Guid, string> AnchorLocatedError;
+
         #endregion Events
 
         /// <summary>

--- a/XRTK.SpatialPersistence/Packages/com.xrtk.spatial-persistence/Runtime/Services/SpatialPersistenceSystem.cs
+++ b/XRTK.SpatialPersistence/Packages/com.xrtk.spatial-persistence/Runtime/Services/SpatialPersistenceSystem.cs
@@ -68,6 +68,7 @@ namespace XRTK.Services.SpatialPersistence
                     provider.SpatialPersistenceStatusMessage += OnSpatialPersistenceStatusMessage;
                     provider.AnchorUpdated += OnAnchorUpdated;
                     provider.AnchorLocated += OnAnchorLocated;
+                    provider.AnchorLocatedError += OnAnchorLocatedError;
                     provider.SpatialPersistenceError += OnSpatialPersistenceError;
                 }
                 else
@@ -77,6 +78,7 @@ namespace XRTK.Services.SpatialPersistence
                     provider.SpatialPersistenceStatusMessage -= OnSpatialPersistenceStatusMessage;
                     provider.AnchorUpdated -= OnAnchorUpdated;
                     provider.AnchorLocated -= OnAnchorLocated;
+                    provider.AnchorLocatedError -= OnAnchorLocatedError;
                     provider.SpatialPersistenceError -= OnSpatialPersistenceError;
                 }
             }
@@ -192,6 +194,10 @@ namespace XRTK.Services.SpatialPersistence
         /// <inheritdoc />
         public event Action<Guid, GameObject> AnchorLocated;
         private void OnAnchorLocated(Guid id, GameObject anchoredGameObject) => AnchorLocated?.Invoke(id, anchoredGameObject);
+
+        /// <inheritdoc />
+        public event Action<Guid, string> AnchorLocatedError;
+        private void OnAnchorLocatedError(Guid id, string exception) => AnchorLocatedError?.Invoke(id, exception);
 
         #endregion IMixedRealitySpatialPersistenceSystem Implementation
     }


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
Added a new event to handle anchors with invalid data that a client would need to handle/delete/resolve

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Added new AnchorLocatedError event, to return the guid of the failed anchor and an exception message.

## Related Submodule Changes

<!--  Include any submodule related Pull Request links here -->
- [Added Try/Catch to handle obscure errors returned from the ASA system](https://github.com/XRTK/SpatialPersistence.ASA/pull/8)
